### PR TITLE
Replaced deprecated ModuleToProcess in PSReflect.psd1

### DIFF
--- a/Lib/PSReflect/PSReflect.psd1
+++ b/Lib/PSReflect/PSReflect.psd1
@@ -1,6 +1,6 @@
 ﻿@{
 # Script module or binary module file associated with this manifest.
-ModuleToProcess = 'PSReflect.psm1'
+RootModule = 'PSReflect.psm1'
 
 # Version number of this module.
 ModuleVersion = '1.1.1.0'


### PR DESCRIPTION
Test-ModuleManifest .\PowerShellArsenal.psd1 reports that
ModuleToProcess is deprecated and to use RootModule instead.